### PR TITLE
Fix bookmark serial type bug

### DIFF
--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -404,7 +404,6 @@ class DatabaseHelper {
         'novel_title': title,
         'author': author,
         'last_viewed': DateTime.now().millisecondsSinceEpoch,
-        'is_serial_novel': isSerialNovelFromUrl(novelId) ? 1 : 0,
       },
       where: 'novel_id = ?',
       whereArgs: [novelId],


### PR DESCRIPTION
## Summary
- prevent `updateBookmarkInfo` from erroneously resetting the serial flag

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426d2f556c832b9748cb9b02dd678e