### PR TITLE
Update reading list tabs refresh and sorting

### DIFF
--- a/lib/viewmodels/bookmark_viewmodel.dart
+++ b/lib/viewmodels/bookmark_viewmodel.dart
@@ -11,7 +11,6 @@ class BookmarkViewModel extends ChangeNotifier {
   bool _isLoading = false;
   bool _isUpdatingFromApi = false;
   bool _isDisposed = false;
-  bool _hasInitialApiUpdate = false; // 初回API更新フラグ
   DateTime? _lastApiUpdateTime; // 最後のAPI更新時刻
   
   static const Duration _apiCooldownDuration = Duration(seconds: 30); // クールタイム
@@ -120,11 +119,9 @@ class BookmarkViewModel extends ChangeNotifier {
     try {
       if (!_isDisposed) {
         _bookmarks = await _dbHelper.getBookmarks();
-        
-        // 初回またはforceApiUpdateの場合のみAPI更新
-        if (!_hasInitialApiUpdate || forceApiUpdate) {
+
+        if (forceApiUpdate) {
           await _updateBookmarksFromApiInternal();
-          _hasInitialApiUpdate = true;
         }
       }
     } catch (e) {

--- a/lib/viewmodels/history_viewmodel.dart
+++ b/lib/viewmodels/history_viewmodel.dart
@@ -11,7 +11,6 @@ class HistoryViewModel extends ChangeNotifier {
   bool _isLoading = false;
   bool _isUpdatingFromApi = false;
   bool _isDisposed = false;
-  bool _hasInitialApiUpdate = false; // 初回API更新フラグ
   DateTime? _lastApiUpdateTime; // 最後のAPI更新時刻
   
   static const Duration _apiCooldownDuration = Duration(seconds: 30); // クールタイム
@@ -120,11 +119,9 @@ class HistoryViewModel extends ChangeNotifier {
     try {
       if (!_isDisposed) {
         _history = await _dbHelper.getAllReadingHistory();
-        
-        // 初回またはforceApiUpdateの場合のみAPI更新
-        if (!_hasInitialApiUpdate || forceApiUpdate) {
+
+        if (forceApiUpdate) {
           await _updateHistoryFromApiInternal();
-          _hasInitialApiUpdate = true;
         }
       }
     } catch (e) {

--- a/lib/views/screens/main_screen.dart
+++ b/lib/views/screens/main_screen.dart
@@ -16,9 +16,11 @@ class _MainScreenState extends State<MainScreen> {
   int _selectedIndex = 0;
   final PageController _pageController = PageController();
 
+  final GlobalKey<ReadingListScreenState> _readingListKey = GlobalKey();
+
   // 各画面のインスタンスを一度だけ作成して保持
   late final List<Widget> _screens = [
-    const ReadingListScreen(),
+    ReadingListScreen(key: _readingListKey),
     const RankingScreen(),
     const ReviewScreen(),
     const SearchScreen(),
@@ -55,6 +57,9 @@ class _MainScreenState extends State<MainScreen> {
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
           );
+          if (index == 0) {
+            _readingListKey.currentState?.reloadTabs();
+          }
         },
         items: const [
           BottomNavigationBarItem(


### PR DESCRIPTION
## Summary
- move tab sort controls to the `ReadingListScreen` app bar
- remove individual app bars from BookmarkTab and HistoryTab
- refresh bookmark/history lists whenever the book tab is tapped
- trigger API updates via pull‑to‑refresh

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684275f89aa4832b9c225f09b159d02c