### PR TITLE
Fix serial novel history

### DIFF
--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -185,13 +185,15 @@ class DatabaseHelper {
   }
 
   Future<void> updateReadingHistoryInfo(
-      String novelId, String title, String author, int totalChapters) async {
+      String novelId, String title, String author, int totalChapters,
+      {bool? isSerialNovel}) async {
     final history = await getReadingHistoryByNovelId(novelId);
     if (history != null) {
       history
         ..novelTitle = title
         ..author = author
         ..totalChapters = totalChapters
+        ..isSerialNovel = isSerialNovel ?? history.isSerialNovel
         ..lastViewed = DateTime.now();
       await history.save();
     }

--- a/lib/viewmodels/webview_viewmodel.dart
+++ b/lib/viewmodels/webview_viewmodel.dart
@@ -214,6 +214,7 @@ class WebViewViewModel extends ChangeNotifier {
           lastViewed: DateTime.now(), // 常に現在時刻で更新
           url: history.url,
           scrollPosition: history.scrollPosition,
+          isSerialNovel: isSerialNovel(novelData),
         );
       } else {
         // API情報がない場合も最終閲覧時刻は更新
@@ -227,6 +228,7 @@ class WebViewViewModel extends ChangeNotifier {
           lastViewed: DateTime.now(),
           url: history.url,
           scrollPosition: history.scrollPosition,
+          isSerialNovel: history.isSerialNovel,
         );
       }
       

--- a/lib/views/screens/webview_screen.dart
+++ b/lib/views/screens/webview_screen.dart
@@ -252,6 +252,7 @@ class _WebViewScreenState extends State<WebViewScreen> with WidgetsBindingObserv
         lastViewed: DateTime.now(),
         url: url,
         scrollPosition: currentScrollPosition,
+        isSerialNovel: _isSerialNovel,
       );
       
       await _viewModel.addToHistory(history, novelData: _novelDetails);
@@ -534,6 +535,7 @@ class _WebViewScreenState extends State<WebViewScreen> with WidgetsBindingObserv
       lastViewed: DateTime.now(),
       url: currentUrl,
       scrollPosition: currentScrollPosition,
+      isSerialNovel: _isSerialNovel,
     );
     
     await _viewModel.addToHistory(history, novelData: _novelDetails);

--- a/lib/views/tabs/history_tab.dart
+++ b/lib/views/tabs/history_tab.dart
@@ -309,7 +309,7 @@ class HistoryTabState extends State<HistoryTab>
                   ),
                   const SizedBox(width: 4),
                   Text(
-                    item.currentChapter > 0 
+                    item.isSerialNovel && item.currentChapter > 0
                         ? '第${item.currentChapter}話まで読了'
                         : '目次/短編',
                     style: const TextStyle(
@@ -635,8 +635,8 @@ class HistoryTabState extends State<HistoryTab>
               mainAxisSize: MainAxisSize.min,
               children: [
                 _buildInfoRow('作者', item.author),
-                _buildInfoRow('現在の章', item.currentChapter > 0 
-                    ? '第${item.currentChapter}話' 
+                _buildInfoRow('現在の章', item.isSerialNovel && item.currentChapter > 0
+                    ? '第${item.currentChapter}話'
                     : '目次/短編'),
                 if (item.totalChapters > 0)
                   _buildInfoRow('総章数', '${item.totalChapters}話'),


### PR DESCRIPTION
## Summary
- pass `isSerialNovel` to history entries from the WebView
- preserve `isSerialNovel` when constructing history updates
- persist the serial flag when updating history info
- show chapter numbers correctly for serial novels

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684282240dd0832bbfe6b12d1e60c314