### PR TITLE
Relax chapter URL regex

### DIFF
--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -147,14 +147,15 @@ class DatabaseHelper {
 
   bool isSerialNovelFromUrl(String url) {
     final serialRegex =
-        RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?');
+        RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?.*');
     return serialRegex.hasMatch(url);
   }
 
   int extractChapterFromUrl(String url) {
     if (!isSerialNovelFromUrl(url)) return 0;
 
-    final regex = RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?');
+    final regex =
+        RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?.*');
     final match = regex.firstMatch(url);
 
     if (match != null) {

--- a/lib/viewmodels/webview_viewmodel.dart
+++ b/lib/viewmodels/webview_viewmodel.dart
@@ -45,7 +45,8 @@ class WebViewViewModel extends ChangeNotifier {
       // なろうのURL形式に対応
       // https://ncode.syosetu.com/n9893km/ または
       // https://ncode.syosetu.com/n9893km/1/ など
-      final regex = RegExp(r'https://ncode\.syosetu\.com/([a-zA-Z0-9]+)/?');
+      final regex =
+          RegExp(r'https://ncode\.syosetu\.com/([a-zA-Z0-9]+)/?.*');
       final match = regex.firstMatch(url);
       
       if (match != null) {
@@ -260,7 +261,8 @@ class WebViewViewModel extends ChangeNotifier {
   bool isNovelContentUrl(String url) {
     try {
       // なろうの小説ページかどうかチェック
-      final novelRegex = RegExp(r'https://ncode\.syosetu\.com/([a-zA-Z0-9]+)(/[0-9]+)?/?$');
+      final novelRegex =
+          RegExp(r'https://ncode\.syosetu\.com/([a-zA-Z0-9]+)(/[0-9]+)?/?.*');
       return novelRegex.hasMatch(url);
     } catch (e) {
       print('小説URL判定エラー: $e');
@@ -285,7 +287,8 @@ class WebViewViewModel extends ChangeNotifier {
   /// URLから章番号を抽出（プライベートメソッドの代替）
   int _extractChapterFromUrl(String url) {
     try {
-      final regex = RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?$');
+      final regex =
+          RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?.*');
       final match = regex.firstMatch(url);
       
       if (match != null) {
@@ -431,7 +434,8 @@ class WebViewViewModel extends ChangeNotifier {
 
   /// URLから小説種別を判定するヘルパーメソッド
   bool isSerialNovelFromUrl(String url) {
-    final serialRegex = RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?$');
+    final serialRegex =
+        RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?.*');
     return serialRegex.hasMatch(url);
   }
 
@@ -603,7 +607,8 @@ class WebViewViewModel extends ChangeNotifier {
     try {
       // URLから章番号を抽出を試行
       if (isSerialNovelFromUrl(currentUrl)) {
-        final regex = RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?$');
+        final regex =
+            RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?.*');
         final match = regex.firstMatch(currentUrl);
         if (match != null) {
           return int.tryParse(match.group(2)!) ?? 1;

--- a/lib/views/screens/webview_screen.dart
+++ b/lib/views/screens/webview_screen.dart
@@ -74,7 +74,8 @@ class _WebViewScreenState extends State<WebViewScreen> with WidgetsBindingObserv
   }
 
   bool _isSerialNovelFromUrl(String url) {
-    final serialRegex = RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?$');
+    final serialRegex =
+        RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?.*');
     return serialRegex.hasMatch(url);
   }
 
@@ -93,7 +94,8 @@ class _WebViewScreenState extends State<WebViewScreen> with WidgetsBindingObserv
   int _extractChapterFromUrl(String url) {
     if (!_isSerialNovel) return 0; // 目次/短編の場合は章番号なし
     
-    final regex = RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?$');
+    final regex =
+        RegExp(r'https://ncode\.syosetu\.com/([^/]+)/([0-9]+)/?.*');
     final match = regex.firstMatch(url);
     
     if (match != null) {


### PR DESCRIPTION
## Summary
- allow optional query string or fragment when parsing chapter numbers
- update chapter parsing in database helper and webview classes

## Testing
- `dart format -o none --set-exit-if-changed lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428ac62c28832bb22b4d2717cb646f