### PR TITLE
Add debug snackbar on WebView load

### DIFF
--- a/lib/views/screens/webview_screen.dart
+++ b/lib/views/screens/webview_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'dart:async';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:flutter/foundation.dart';
 import '../../viewmodels/webview_viewmodel.dart';
 import '../../models/reading_history.dart';
 import '../../providers/theme_provider.dart';
@@ -211,7 +212,16 @@ class _WebViewScreenState extends State<WebViewScreen> with WidgetsBindingObserv
             }
             
             _updateNavigationState();
-            
+
+            if (kDebugMode && mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('WebViewの読み込みが完了しました'),
+                  duration: Duration(seconds: 1),
+                ),
+              );
+            }
+
             try {
               await _updateChapterFromUrl(url);
               


### PR DESCRIPTION
## Summary
- show a snackbar when a WebView finishes loading
- import `foundation.dart` for `kDebugMode`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f626c4288832b97070a62f8df8271